### PR TITLE
Fix #8 rotate command

### DIFF
--- a/src/main/java/io/github/misode/packtest/dummy/Dummy.java
+++ b/src/main/java/io/github/misode/packtest/dummy/Dummy.java
@@ -9,6 +9,7 @@ import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.game.ClientboundEntityPositionSyncPacket;
 import net.minecraft.network.protocol.game.ClientboundRotateHeadPacket;
 import net.minecraft.network.protocol.game.ServerboundClientCommandPacket;
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.TickTask;
@@ -95,6 +96,15 @@ public class Dummy extends ServerPlayer {
 
     public void respawn() {
         server.getPlayerList().respawn(this, false, Entity.RemovalReason.KILLED);
+    }
+
+    @Override
+    public void forceSetRotation(float f, float g) {
+        this.setYRot(f);
+        this.setXRot(g);
+        this.setOldRot();
+
+        this.connection.send(new ServerboundMovePlayerPacket.Rot(f, g, false, false));
     }
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
This is a simple fix for dummy players not rotating when using the `/rotate` command. Now it should works as expected.

Also, this is totally out of scope for this PR, but just wondering, is there any plan to fix the reload issue? Like loading new tests after a reload, and not failing when tests are removed?